### PR TITLE
Generate MonadError exceptions instead of calling error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 dist*/
+.boring
+_darcs/
+

--- a/itanium-abi.cabal
+++ b/itanium-abi.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name: itanium-abi
-version: 0.1.1.1
+version: 0.1.1.1.99
 synopsis: An implementation of name mangling/demangling for the Itanium ABI
 license: BSD3
 license-file: LICENSE

--- a/itanium-abi.cabal
+++ b/itanium-abi.cabal
@@ -24,6 +24,7 @@ library
   ghc-options: -Wall
   build-depends: base >= 4 && < 5,
                  boomerang >= 1.4.5.6 && < 1.5,
+                 exceptions >= 0.10 && < 0.11,
                  text >= 0.11 && < 2,
                  transformers,
                  unordered-containers >= 0.2.3.0 && < 0.3

--- a/tests/DemangleTests.hs
+++ b/tests/DemangleTests.hs
@@ -13,8 +13,9 @@ mkTestCase (sym, expected) = testCase sym $ do
   case demangleName sym of
     Left err -> assertFailure (sym ++ " : " ++ err)
     Right dname ->
-      cxxNameToString dname >>=
-        \s -> assertEqual sym (normalize expected) (normalize s)
+      case cxxNameToString dname of
+        Left err -> assertFailure (sym ++ " pretty-printing: " ++ show err)
+        Right s -> assertEqual sym (normalize expected) (normalize s)
   where
     normalize = filter (`notElem` "\n")
 

--- a/tests/DemangleTests.hs
+++ b/tests/DemangleTests.hs
@@ -13,7 +13,8 @@ mkTestCase (sym, expected) = testCase sym $ do
   case demangleName sym of
     Left err -> assertFailure (sym ++ " : " ++ err)
     Right dname ->
-      assertEqual sym (normalize expected) (normalize (cxxNameToString dname))
+      cxxNameToString dname >>=
+        \s -> assertEqual sym (normalize expected) (normalize s)
   where
     normalize = filter (`notElem` "\n")
 


### PR DESCRIPTION
This allows the main application to handle mangled name pretty-printing errors instead of the `error` call which usually results in application exit.