### PR TITLE
Allow building with `text-2.0`

### DIFF
--- a/itanium-abi.cabal
+++ b/itanium-abi.cabal
@@ -25,7 +25,7 @@ library
   build-depends: base >= 4 && < 5,
                  boomerang >= 1.4.5.6 && < 1.5,
                  exceptions >= 0.10 && < 0.11,
-                 text >= 0.11 && < 2,
+                 text >= 0.11 && < 2.1,
                  transformers,
                  unordered-containers >= 0.2.3.0 && < 0.3
   exposed-modules: ABI.Itanium


### PR DESCRIPTION
This is the `text` version bundled with GHC 9.4.