### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/itanium-abi.cabal
+++ b/itanium-abi.cabal
@@ -26,7 +26,7 @@ library
   build-depends: base >= 4 && < 5,
                  boomerang >= 1.4.5.6 && < 1.5,
                  exceptions >= 0.10 && < 0.11,
-                 text >= 0.11 && < 2.1,
+                 text >= 0.11 && < 2.2,
                  transformers,
                  unordered-containers >= 0.2.3.0 && < 0.3
   exposed-modules: ABI.Itanium

--- a/src/ABI/Itanium/Pretty.hs
+++ b/src/ABI/Itanium/Pretty.hs
@@ -608,14 +608,16 @@ showType t =
       -- stub will never be referenced because function types aren't
       -- first-class
       ts' <- mapM showType ts
-      if null ts'
-        then return()
-        else recordSubstitution'
-             $ mconcat [ head ts'
-                       , fromString " ("
-                       , mconcat $ intersperse (fromString ", ") $ tail ts'
-                       , singleton ')'
-                       ]
+      case ts' of
+        [] ->
+          return()
+        ty:tys ->
+          recordSubstitution'
+          $ mconcat [ ty
+                    , fromString " ("
+                    , mconcat $ intersperse (fromString ", ") tys
+                    , singleton ')'
+                    ]
       r <- showFunctionType ts
       recordSubstitution $! r
     PointerToType t' -> do


### PR DESCRIPTION
Bump the upper version bounds to allow building with `text-2.1.*`, which is bundled with GHC 9.8. Also fix `-Wx-partial` warnings caused by uses of the `head` and `tail` functions.